### PR TITLE
Enable `RTLD_DEEPBIND` by default, add workaround for musl and FreeBSD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ include $(LBT_ROOT)/src/Make.inc
 all: $(builddir)/libblastrampoline.$(SHLIB_EXT)
 
 # Objects we'll build
-MAIN_OBJS := libblastrampoline.o dl_utils.o autodetection.o trampolines/trampolines_$(ARCH).o
+MAIN_OBJS := libblastrampoline.o dl_utils.o autodetection.o surrogates.o trampolines/trampolines_$(ARCH).o
 
 # Include win_utils.c on windws
 ifeq ($(OS),WINNT)

--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -44,7 +44,11 @@ int autodetect_blas_interface(void * isamax_addr) {
     int64_t n = 0xffffffff00000003;
     float X[3] = {1.0f, 2.0f, 1.0f};
     int64_t incx = 1;
+
+    // Override `lsame_` to point to our `fake_lsame`
+    push_fake_lsame();
     int64_t max_idx = isamax(&n, X, &incx);
+    pop_fake_lsame();
 
     // This means the `isamax()` implementation saw `N < 0`, ergo it's a 64-bit library
     if (max_idx == 0) {

--- a/src/dl_utils.c
+++ b/src/dl_utils.c
@@ -22,8 +22,7 @@ void throw_dl_error(const char * path) {
 
 
 /*
- * Load the given `path`, using as close to `RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND`
- * as possible across all platforms.
+ * Load the given `path`, using `RTLD_NOW | RTLD_LOCAL` and `RTLD_DEEPBIND`, if available
  */
 void * load_library(const char * path) {
     void * new_handle = NULL;
@@ -35,10 +34,13 @@ void * load_library(const char * path) {
         exit(1);
     }
     new_handle = (void *)LoadLibraryExW(wpath, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
-#elif defined(_OS_DARWIN_) || defined(_OS_FREEBSD_)
-    new_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 #else
+    // If we have `RTLD_DEEPBIND`, use it!
+#if defined(RTLD_DEEPBIND)
     new_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
+#else
+    new_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+#endif
 #endif
     if (new_handle == NULL) {
         throw_dl_error(path);

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -34,6 +34,11 @@
 // This is the maximum length of a symbol that we'll allow
 #define MAX_SYMBOL_LEN 64
 
+// Data defined in `libblastrampoline_trampdata.h
+extern const char *const exported_func_names[];
+extern const void ** exported_func32_addrs[];
+extern const void ** exported_func64_addrs[];
+
 // Functions in `win_utils.c`
 int wchar_to_utf8(const wchar_t * wstr, char *str, size_t maxlen);
 int utf8_to_wchar(const char * str, wchar_t * wstr, size_t maxlen);
@@ -47,3 +52,8 @@ const char * autodetect_symbol_suffix(void * handle);
 int autodetect_blas_interface(void * isamax_addr);
 int autodetect_lapack_interface(void * dpotrf_addr);
 int autodetect_interface(void * handle, const char * suffix);
+
+// Functions in surrogates.c
+void push_fake_lsame();
+void pop_fake_lsame();
+int fake_lsame(char * ca, char * cb);

--- a/src/libblastrampoline_trampdata.h
+++ b/src/libblastrampoline_trampdata.h
@@ -14,7 +14,7 @@ EXPORTED_FUNCS(XX_64)
 
 // Generate list of function names
 #define XX(name)    #name,
-static const char *const exported_func_names[] = {
+const char *const exported_func_names[] = {
     EXPORTED_FUNCS(XX)
     NULL
 };
@@ -23,11 +23,11 @@ static const char *const exported_func_names[] = {
 // Generate list of function addresses to tie names -> variables
 #define XX(name)    &name##_addr,
 #define XX_64(name) &name##64__addr,
-static const void ** exported_func32_addrs[] = {
+const void ** exported_func32_addrs[] = {
     EXPORTED_FUNCS(XX)
     NULL
 };
-static const void ** exported_func64_addrs[] = {
+const void ** exported_func64_addrs[] = {
     EXPORTED_FUNCS(XX_64)
     NULL
 };

--- a/src/surrogates.c
+++ b/src/surrogates.c
@@ -1,0 +1,82 @@
+#include "libblastrampoline_internal.h"
+
+int find_symbol_idx(const char * name) {
+    for (int symbol_idx=0; exported_func_names[symbol_idx] != NULL; ++symbol_idx) {
+        if (strcmp(exported_func_names[symbol_idx], "lsame_") == 0) {
+            return symbol_idx;
+        }
+    }
+
+    // This is fatal as it signifies a configuration error in our trampoline symbol list
+    fprintf(stderr, "Error: Unable to find %s in our symbol list?!\n", name);
+    exit(1);
+}
+
+int lsame_idx = -1;
+const void *old_lsame32 = NULL, *old_lsame64 = NULL;
+void push_fake_lsame() {
+    // Find `lsame_` in our symbol list (if we haven't done so before)
+    if (lsame_idx == -1)
+        lsame_idx = find_symbol_idx("lsame_");
+    
+    // Save old values of `lsame_` and `lsame_64_` to our swap location
+    old_lsame32 = (*exported_func32_addrs[lsame_idx]);
+    old_lsame64 = (*exported_func64_addrs[lsame_idx]);
+
+    // Insert our "fake" lsame in so that we always have a half-functional copy
+    (*exported_func32_addrs[lsame_idx]) = &fake_lsame;
+    (*exported_func64_addrs[lsame_idx]) = &fake_lsame;
+}
+
+void pop_fake_lsame() {
+    if (lsame_idx == -1) {
+        // Did you call `pop_fake_lsame()` without calling `push_fake_lsame()` first?!
+        fprintf(stderr, "pop_fake_lsame() called with invalid `lsame_idx`!\n");
+        exit(1);
+    }
+
+    (*exported_func32_addrs[lsame_idx]) = old_lsame32;
+    (*exported_func64_addrs[lsame_idx]) = old_lsame64;
+
+    old_lsame32 = NULL;
+    old_lsame64 = NULL;
+}
+
+
+/* `lsame_` implementation taken from `http://www.netlib.org/clapack/cblas/lsame.c`*/
+int fake_lsame(char * ca, char * cb) {
+    /* Local variables */
+    static int inta, intb, zcode;
+
+    if (*(unsigned char *)ca == *(unsigned char *)cb) {
+	    return 1;
+    }
+
+    zcode = 'Z';
+    inta = *(unsigned char *)ca;
+    intb = *(unsigned char *)cb;
+
+    if (zcode == 90 || zcode == 122) {
+        if (inta >= 97 && inta <= 122) {
+            inta += -32;
+        }
+        if (intb >= 97 && intb <= 122) {
+            intb += -32;
+        }
+    } else if (zcode == 233 || zcode == 169) {
+        if (inta >= 129 && inta <= 137 || inta >= 145 && inta <= 153 || inta >= 162 && inta <= 169) {
+            inta += 64;
+        }
+        if (intb >= 129 && intb <= 137 || intb >= 145 && intb <= 153 || intb >= 162 && intb <= 169) {
+            intb += 64;
+        }
+    } else if (zcode == 218 || zcode == 250) {
+        if (inta >= 225 && inta <= 250) {
+            inta += -32;
+        }
+        if (intb >= 225 && intb <= 250) {
+            intb += -32;
+        }
+    }
+    return inta == intb;
+}


### PR DESCRIPTION
We allow the vast majority of functionality for musl and FreeBSD, the
only two systems that do not have `RTLD_DEEPBIND` functionality.  Our
method enables usage of most combinations of BLAS libraries, with the
exception of a 32-bit BLAS and a 64-bit BLAS that uses no suffix on its
symbols.