### PR TITLE
Test MKL ILP64 through environment variable

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,11 +112,13 @@ if MKL_jll.is_available()
     end
 
     # Test that we can set MKL's interface via an environment variable to select ILP64, and LBT detects it properly
-    @testset "LBT -> MKL_jll (ILP64, via env)" begin
-        withenv("MKL_INTERFACE_LAYER" => "ILP64") do
-            libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
-            run_test(dgemm, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path)
-            run_test(sgesv, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path) 
+    if Sys.WORD_SIZE == 64
+        @testset "LBT -> MKL_jll (ILP64, via env)" begin
+            withenv("MKL_INTERFACE_LAYER" => "ILP64") do
+                libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+                run_test(dgemm, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path)
+                run_test(sgesv, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path) 
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,16 @@ if MKL_jll.is_available()
     @testset "LBT -> MKL_jll (LP64)" begin
         libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
         run_test(dgemm, "blastrampoline", libdirs, :LP64, MKL_jll.libmkl_rt_path)
-        run_test(sgesv, "blastrampoline", libdirs, :LP64, MKL_jll.libmkl_rt_path)
+        run_test(sgesv, "blastrampoline", libdirs, :LP64, MKL_jll.libmkl_rt_path) 
+    end
+
+    # Test that we can set MKL's interface via an environment variable to select ILP64, and LBT detects it properly
+    @testset "LBT -> MKL_jll (ILP64, via env)" begin
+        withenv("MKL_INTERFACE_LAYER" => "ILP64") do
+            libdirs = unique(vcat(MKL_jll.LIBPATH_list..., CompilerSupportLibraries_jll.LIBPATH_list..., lbt_dir))
+            run_test(dgemm, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path)
+            run_test(sgesv, "blastrampoline", libdirs, :ILP64, MKL_jll.libmkl_rt_path) 
+        end
     end
 end
 


### PR DESCRIPTION
We want to test ILP64 MKL as well; do so by setting
`MKL_INTERFACE_LAYER` to `ILP64` and then re-running the MKL test.  In
practice, because LBT classifies MKL as LP64 or ILP64 at load time,
we'll need to either:

  - Load `libmkl_rt` first, call `mkl_set_interface_layer()` first, then
    pass it to LBT for forwarding
  - Load `libmkl_rt`, then use LBT to set it to ILP64 and clear/reload
    it to drop the now-erroneous 32-bit bindings and pick up the
    correctly-configured 64-bit bindings.
  - Always set the environment variable before loading the library (no)