### PR TITLE
Only use surrogate `lsame` on RTLD_DEEPBIND-less systems

### DIFF
--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -45,10 +45,14 @@ int autodetect_blas_interface(void * isamax_addr) {
     float X[3] = {1.0f, 2.0f, 1.0f};
     int64_t incx = 1;
 
-    // Override `lsame_` to point to our `fake_lsame`
+    // Override `lsame_` to point to our `fake_lsame` if we're unable to `RTLD_DEEPBIND`
+#ifdef LBT_DEEPBINDLESS
     push_fake_lsame();
+#endif
     int64_t max_idx = isamax(&n, X, &incx);
+#ifdef LBT_DEEPBINDLESS
     pop_fake_lsame();
+#endif
 
     // This means the `isamax()` implementation saw `N < 0`, ergo it's a 64-bit library
     if (max_idx == 0) {

--- a/src/libblastrampoline.c
+++ b/src/libblastrampoline.c
@@ -106,7 +106,7 @@ JL_DLLEXPORT int lbt_forward(const char * libname, int clear, int verbose) {
      * attempts to load another one without setting the `clear` flag, we refuse to
      * load it on a deepbindless system, printing out to `stderr` if we're verbose.
      */
-#if !defined(RTLD_DEEPBIND) && (defined(_OS_LINUX_) || defined(_OS_FREEBSD_))
+#if LBT_DEEPBINDLESS
     // If `clear` is set, we clear our tracking
     if (clear) {
         deepbindless_interfaces_loaded = 0x00;

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -31,6 +31,10 @@
 #include <limits.h>
 #endif
 
+#if !defined(RTLD_DEEPBIND) && (defined(_OS_LINUX_) || defined(_OS_FREEBSD_))
+#define LBT_DEEPBINDLESS
+#endif
+
 // This is the maximum length of a symbol that we'll allow
 #define MAX_SYMBOL_LEN 64
 

--- a/src/surrogates.c
+++ b/src/surrogates.c
@@ -1,5 +1,7 @@
 #include "libblastrampoline_internal.h"
 
+#ifdef LBT_DEEPBINDLESS
+
 int find_symbol_idx(const char * name) {
     for (int symbol_idx=0; exported_func_names[symbol_idx] != NULL; ++symbol_idx) {
         if (strcmp(exported_func_names[symbol_idx], "lsame_") == 0) {
@@ -80,3 +82,5 @@ int fake_lsame(char * ca, char * cb) {
     }
     return inta == intb;
 }
+
+#endif // LBT_DEEPBINDLESS


### PR DESCRIPTION
This workaround should only be necessary on systems without an
`RTLD_DEEPBIND`-style linking system.  On those systems, we need to
ensure that `lsame_` points to a reasonable facsimile of itself.