### PR TITLE
Use the properly-capitalized C-ABI MKL threading interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ You can always tell if your system is limited in this fashion by calling `lbt_ge
 
 ### Version History
 
+v3.0.2 - Fix MKL threading interface to use properly-capitalized names to get the C ABI.
+
+v3.0.1 - Don't `dlclose()` libraries; this can cause crashes due to not knowing when resources are truly freed.
+
 v3.0.0 - Added `active_forwards` field to `lbt_libinfo_t` and `exported_symbols` to `lbt_config_t`.
 
 v2.2.0 - Removed useless `exit(1)` in `src/dl_utils.c`.

--- a/src/threading.c
+++ b/src/threading.c
@@ -10,14 +10,14 @@
  */
 static char * getter_names[MAX_THREADING_NAMES] = {
     "openblas_get_num_threads",
-    "mkl_get_max_threads",
+    "MKL_Get_Max_Threads",
     "bli_thread_set_num_threads",
     NULL
 };
 
 static char * setter_names[MAX_THREADING_NAMES] = {
     "openblas_set_num_threads",
-    "mkl_set_num_threads",
+    "MKL_Set_Num_Threads",
     "bli_thread_get_num_threads",
     NULL
 };


### PR DESCRIPTION
It appears that the all-lowercase threading symbols are actually all
FORTRAN ABI, as can be seen through `dlsym()`:

```
julia> dlsym(libmkl_rt, "mkl_set_num_threads")
Ptr{Nothing} @0x00007fa64f24e3b0

julia> dlsym(libmkl_rt, "mkl_set_num_threads_")
Ptr{Nothing} @0x00007fa64f24e3b0
```

The C-ABI versions are not the non-underscore-suffixed ones, but the
capitalized ones, e.g. `MKL_Set_Num_Threads`.  The more you know.