### PR TITLE
Fix armv7l trampoline

### DIFF
--- a/src/trampolines/trampolines_arm.S
+++ b/src/trampolines/trampolines_arm.S
@@ -5,7 +5,7 @@
 .global MANGLE(UNDERSCORE(name)); \
 .cfi_startproc; \
 MANGLE(UNDERSCORE(name))##:; \
-    ldr ip, CONCAT(.L,MANGLE(UNDERSCORE(name))); \
+    ldr ip, CONCAT(.L,NAMEADDR(name)); \
 CONCAT(.L,MANGLE(UNDERSCORE(name))): ;\
     add ip, pc, ip; \
     ldr pc, [ip]; \


### PR DESCRIPTION
We accidentally were loading the wrong name address here.  This was not
caught because we don't have a Julia 1.6 build for armv7l yet, but once
we do we'll be able to properly CI this.