### PR TITLE
Remove vendor-specific APIs from `include/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This support is only available on the `x86_64` and `i686` architectures, however
 ## `libblastrampoline`-specific API
 
 `libblastrampoline` exports a simple configuration API including `lbt_forward()`, `lbt_get_config()`, `lbt_{set,get}_num_threads()`, and more.
+Vendor-specific APIs such as `openblas_get_num_threads()` are not included in header files or exported from the library.
 See the [public header file](src/libblastrampoline.h) for the most up-to-date documentation on the `libblastrampoline` API.
 
 **Note**: all `lbt_*` functions should be considered thread-unsafe.

--- a/ext/build_includes/Manifest.toml
+++ b/ext/build_includes/Manifest.toml
@@ -1,0 +1,464 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgParse]]
+deps = ["Logging", "TextWrap"]
+git-tree-sha1 = "3102bce13da501c9104df33549f511cd25264d7d"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "1.1.4"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[AssetRegistry]]
+deps = ["Distributed", "JSON", "Pidfile", "SHA", "Test"]
+git-tree-sha1 = "b25e88db7944f98789130d7b503276bc34bc098e"
+uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
+version = "0.1.0"
+
+[[AutoHashEquals]]
+git-tree-sha1 = "45bb6705d93be619b81451bb2006b7ee5d4e4453"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "0.2.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinaryBuilder]]
+deps = ["ArgParse", "BinaryBuilderBase", "Dates", "Downloads", "GitHub", "HTTP", "JLD2", "JSON", "LibGit2", "Libdl", "Logging", "LoggingExtras", "ObjectFile", "OutputCollectors", "Pkg", "PkgLicenses", "ProgressMeter", "REPL", "Random", "Registrator", "RegistryTools", "SHA", "Scratch", "Sockets", "UUIDs", "ghr_jll"]
+git-tree-sha1 = "bc8b3f6cd1f1583feb59d403e11bfec65ee3b701"
+uuid = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+version = "0.3.6"
+
+[[BinaryBuilderBase]]
+deps = ["CodecZlib", "Downloads", "InteractiveUtils", "JSON", "LibGit2", "Libdl", "Logging", "OutputCollectors", "Pkg", "Random", "SHA", "Scratch", "SimpleBufferStream", "TOML", "Tar", "UUIDs", "p7zip_jll", "pigz_jll"]
+git-tree-sha1 = "896d7eb00c840985175f467f2b23cd16b29a6f01"
+uuid = "7f725544-6523-48cd-82d1-3fa08ff4056e"
+version = "0.6.7"
+
+[[CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "e4e2b39db08f967cc1360951f01e8a75ec441cab"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.30.0"
+
+[[DataAPI]]
+git-tree-sha1 = "dfb3b7e89e395be1e25c2ad6d7690dc29cc53b1d"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.6.0"
+
+[[DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.9"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[ExprTools]]
+git-tree-sha1 = "10407a39b87f29d47ebaca8edbc75d7c302ff93e"
+uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+version = "0.1.3"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[GitForge]]
+deps = ["Dates", "HTTP", "JSON2"]
+git-tree-sha1 = "0e6b8635059d6ac9e421825e75f8fca170f557d2"
+uuid = "8f6bce27-0656-5410-875b-07a5572985df"
+version = "0.1.7"
+
+[[GitHub]]
+deps = ["Base64", "Dates", "HTTP", "JSON", "MbedTLS", "Sockets", "SodiumSeal"]
+git-tree-sha1 = "a4f61fc1b1724e6eec1d9333eac2d4b01d8fcc8f"
+uuid = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+version = "5.4.0"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "86ed84701fbfd1142c9786f8e53c595ff5a4def9"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.10"
+
+[[Hiccup]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "6187bb2d5fcbb2007c39e7ac53308b0d371124bd"
+uuid = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
+version = "0.2.2"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLD2]]
+deps = ["CodecZlib", "DataStructures", "MacroTools", "Mmap", "Pkg", "Printf", "Requires", "UUIDs"]
+git-tree-sha1 = "9f2f2f24e60305feb6ae293a617ddf06f429efc3"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.4.3"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[JSON2]]
+deps = ["Dates", "Parsers", "Test"]
+git-tree-sha1 = "66397cc6c08922f98a28ab05a8d3002f9853b129"
+uuid = "2535ab7d-5cd8-5a07-80ac-9b1792aadce3"
+version = "0.3.2"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "59b45fd91b743dff047313bb7af0f84167aef80d"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "0.4.6"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Mocking]]
+deps = ["ExprTools"]
+git-tree-sha1 = "916b850daad0d46b8c71f65f719c49957e9513ed"
+uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
+version = "0.7.1"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[Mustache]]
+deps = ["Printf", "Tables"]
+git-tree-sha1 = "36995ef0d532fe08119d70b2365b7b03d4e00f48"
+uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+version = "1.0.10"
+
+[[Mux]]
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Pkg", "Sockets", "WebSockets"]
+git-tree-sha1 = "82dfb2cead9895e10ee1b0ca37a01088456c4364"
+uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
+version = "0.7.6"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[ObjectFile]]
+deps = ["Reexport", "StructIO", "Test"]
+git-tree-sha1 = "e009c49f99dac98cb79f93b26c259ebca66eff26"
+uuid = "d8793406-e978-5875-9003-1fc021f44a92"
+version = "0.3.6"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[OutputCollectors]]
+git-tree-sha1 = "d86c19b7fa8ad6a4dc8ec2c726642cc6291b2941"
+uuid = "6c11c7d4-943b-4e2b-80de-f2cfc2930a8c"
+version = "0.1.0"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.1.0"
+
+[[Pidfile]]
+deps = ["FileWatching", "Test"]
+git-tree-sha1 = "1be8660b2064893cd2dae4bd004b589278e4440d"
+uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+version = "1.2.0"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PkgLicenses]]
+deps = ["Test"]
+git-tree-sha1 = "0af826be249c6751a3e783c07b8cd3034f508943"
+uuid = "fc669557-7ec9-5e45-bca9-462afbc28879"
+version = "0.2.0"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "afadeba63d90ff223a6a48d2009434ecee2ec9e8"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.7.1"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Registrator]]
+deps = ["AutoHashEquals", "Base64", "Dates", "Distributed", "FileWatching", "GitForge", "GitHub", "HTTP", "JSON", "LibGit2", "Logging", "MbedTLS", "Mocking", "Mustache", "Mux", "Pkg", "RegistryTools", "Serialization", "Sockets", "TimeToLive", "UUIDs", "ZMQ"]
+git-tree-sha1 = "eb26e0318f789ab976ba351e76c37ffafa726154"
+uuid = "4418983a-e44d-11e8-3aec-9789530b3b3e"
+version = "1.2.5"
+
+[[RegistryTools]]
+deps = ["AutoHashEquals", "LibGit2", "Pkg", "UUIDs"]
+git-tree-sha1 = "a1b5b98de15341137ef9bbdb40c7629297bc8d9b"
+uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
+version = "1.5.6"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.3"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "ad4b278adb62d185bbcb6864dc24959ab0627bf6"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.0.3"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[SimpleBufferStream]]
+git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.1.0"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SodiumSeal]]
+deps = ["Base64", "Libdl", "libsodium_jll"]
+git-tree-sha1 = "80cef67d2953e33935b41c6ab0a178b9987b1c99"
+uuid = "2133526b-2bfb-4018-ac12-889fb3908a75"
+version = "0.1.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StructIO]]
+deps = ["Test"]
+git-tree-sha1 = "010dc73c7146869c042b49adcdb6bf528c12e859"
+uuid = "53d494c1-5632-5724-8f4c-31dff12d585f"
+version = "0.3.0"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "aa30f8bb63f9ff3f8303a06c604c8500a69aa791"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.4.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TextWrap]]
+git-tree-sha1 = "9250ef9b01b66667380cf3275b3f7488d0e25faf"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "1.0.1"
+
+[[TimeToLive]]
+deps = ["Dates"]
+git-tree-sha1 = "1f1389007d16385ec02e497bef6c2caffba99b65"
+uuid = "37f0c46e-897f-50ef-b453-b26c3eed3d6c"
+version = "0.3.0"
+
+[[TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.5"
+
+[[URIs]]
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.3.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[WebSockets]]
+deps = ["Base64", "Dates", "HTTP", "Logging", "Sockets"]
+git-tree-sha1 = "f91a602e25fe6b89afc93cf02a4ae18ee9384ce3"
+uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
+version = "1.5.9"
+
+[[ZMQ]]
+deps = ["FileWatching", "Sockets", "ZeroMQ_jll"]
+git-tree-sha1 = "fc68e8a3719166950a0f3e390a14c7302c48f8de"
+uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
+version = "1.2.1"
+
+[[ZeroMQ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "libsodium_jll"]
+git-tree-sha1 = "74a74a3896b63980734cc876da8a103454559fe8"
+uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
+version = "4.3.2+6"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[ghr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f5c8cb306d4fe2d1fff90443a088fc5ba536c134"
+uuid = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
+version = "0.13.0+1"
+
+[[libsodium_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "848ab3d00fe39d6fbc2a8641048f8f272af1c51e"
+uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
+version = "1.0.20+0"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+
+[[pigz_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "8c379a72c82099ceb4be53f4f427690376279052"
+uuid = "1bc43ea1-30af-5bc8-a9d4-c018457e6e3e"
+version = "2.5.0+0"

--- a/ext/build_includes/Project.toml
+++ b/ext/build_includes/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/ext/build_includes/build_includes.jl
+++ b/ext/build_includes/build_includes.jl
@@ -8,7 +8,7 @@ version = v"0.3.13"
 for openblas32 in (true, false)
     sources = [
         ArchiveSource("https://github.com/xianyi/OpenBLAS/archive/v$(version).tar.gz",
-                    "79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e")
+                      "79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e")
     ]
 
     script = """
@@ -36,6 +36,10 @@ for openblas32 in (true, false)
 
     # Call `make install`, fully expecting this to blow up in our faces.
     make "\${flags[@]}" "PREFIX=\${prefix}" install || true
+
+    # Comment out vendor-specific functions like `openblas_{s,g}et_num_threads`
+    find \${prefix}/include -name \\*.h | xargs sed -i -E 's&(.*openblas_[sg]et_.*)&//\\1&'
+    find \${prefix}/include -name \\*.bak | xargs rm -f
     """
 
     products = [

--- a/include/ILP64/aarch64-linux-gnu/cblas.h
+++ b/include/ILP64/aarch64-linux-gnu/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/aarch64-linux-musl/cblas.h
+++ b/include/ILP64/aarch64-linux-musl/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/armv7l-linux-gnueabihf/cblas.h
+++ b/include/ILP64/armv7l-linux-gnueabihf/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/armv7l-linux-musleabihf/cblas.h
+++ b/include/ILP64/armv7l-linux-musleabihf/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/i686-linux-gnu/cblas.h
+++ b/include/ILP64/i686-linux-gnu/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/i686-linux-musl/cblas.h
+++ b/include/ILP64/i686-linux-musl/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/i686-w64-mingw32/cblas.h
+++ b/include/ILP64/i686-w64-mingw32/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/powerpc64le-linux-gnu/cblas.h
+++ b/include/ILP64/powerpc64le-linux-gnu/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/x86_64-apple-darwin/cblas.h
+++ b/include/ILP64/x86_64-apple-darwin/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/x86_64-linux-gnu/cblas.h
+++ b/include/ILP64/x86_64-linux-gnu/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/x86_64-linux-musl/cblas.h
+++ b/include/ILP64/x86_64-linux-musl/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/x86_64-unknown-freebsd/cblas.h
+++ b/include/ILP64/x86_64-unknown-freebsd/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/ILP64/x86_64-w64-mingw32/cblas.h
+++ b/include/ILP64/x86_64-w64-mingw32/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads64_(int num_threads);
+//void openblas_set_num_threads64_(int num_threads);
 void goto_set_num_threads64_(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads64_(void);
+//int openblas_get_num_threads64_(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs64_(void);
+//int openblas_get_num_procs64_(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config64_(void);
+//char* openblas_get_config64_(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename64_(void);
+//char* openblas_get_corename64_(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads64_()-1]. */
 int openblas_setaffinity64_(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel64_(void);
+//int openblas_get_parallel64_(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/LP64/common/cblas.h
+++ b/include/LP64/common/cblas.h
@@ -10,28 +10,28 @@ extern "C" {
 #endif  /* __cplusplus */
 
 /*Set the number of threads on runtime.*/
-void openblas_set_num_threads(int num_threads);
+//void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
 /*Get the number of threads on runtime.*/
-int openblas_get_num_threads(void);
+//int openblas_get_num_threads(void);
 
 /*Get the number of physical processors (cores).*/
-int openblas_get_num_procs(void);
+//int openblas_get_num_procs(void);
 
 /*Get the build configure on runtime.*/
-char* openblas_get_config(void);
+//char* openblas_get_config(void);
 
 /*Get the CPU corename on runtime.*/
-char* openblas_get_corename(void);
+//char* openblas_get_corename(void);
 
 #ifdef OPENBLAS_OS_LINUX
-/* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
+///* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);
 #endif
 
 /* Get the parallelization type which is used by OpenBLAS */
-int openblas_get_parallel(void);
+//int openblas_get_parallel(void);
 /* OpenBLAS is compiled for sequential use  */
 #define OPENBLAS_SEQUENTIAL  0
 /* OpenBLAS is compiled using normal threading model */

--- a/include/common/f77blas.h
+++ b/include/common/f77blas.h
@@ -48,7 +48,7 @@ extern "C" {
 
 int    BLASFUNC(xerbla)(char *, blasint *info, blasint);
 
-void    openblas_set_num_threads_(int *);
+//void    openblas_set_num_threads_(int *);
 
 FLOATRET  BLASFUNC(sdot)  (blasint *, float  *, blasint *, float  *, blasint *);
 FLOATRET  BLASFUNC(sdsdot)(blasint *, float  *,        float  *, blasint *, float  *, blasint *);


### PR DESCRIPTION
Since we don't export `openblas_get_num_threads` and friends, let's not
even include it in the headers so that users that build against our C
APIs don't get confused.