### PR TITLE
Force setting of some `CFLAGS` and `LDFLAGS`

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -1,3 +1,5 @@
+# -*- makefile -*-
+
 # ARCH detection in Make, used to pick out which trampoline assembly syntax we're gonna use
 ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")
 
@@ -32,17 +34,18 @@ else
   binlib := lib
 endif
 
-CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS_add)
-LDFLAGS := -shared
+CFLAGS := -g -O2 -std=c99 -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS_add)
+override CFLAGS += -fPIC
+override LDFLAGS += -shared
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`
-LDFLAGS += -ldl
+override LDFLAGS += -ldl
 endif
 
 ifeq ($(OS),WINNT)
 # On windows, we need to enable unicode mode
-CFLAGS += -municode
+override CFLAGS += -municode
 endif
 
 # On windows, we must generate import libraries
@@ -59,7 +62,7 @@ endif
 # from returning doubles to instead return float's.  We enable automatic F2C detection on those platforms.
 F2C_AUTODETECTION := 0
 ifeq ($(ARCH),x86_64)
-  CFLAGS += -DF2C_AUTODETECTION
+  override CFLAGS += -DF2C_AUTODETECTION
   F2C_AUTODETECTION := 1
 endif
 

--- a/src/Make.inc
+++ b/src/Make.inc
@@ -35,7 +35,7 @@ else
 endif
 
 LBT_CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS)
-LBT_LDFLAGS := -shared $(LDFLAGS)
+LBT_LDFLAGS := $(LDFLAGS)
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`

--- a/src/Make.inc
+++ b/src/Make.inc
@@ -34,18 +34,17 @@ else
   binlib := lib
 endif
 
-CFLAGS := -g -O2 -std=c99 -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS_add)
-override CFLAGS += -fPIC
-override LDFLAGS += -shared
+LBT_CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS)
+LBT_LDFLAGS := -shared $(LDFLAGS)
 
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`
-override LDFLAGS += -ldl
+LBT_LDFLAGS += -ldl
 endif
 
 ifeq ($(OS),WINNT)
 # On windows, we need to enable unicode mode
-override CFLAGS += -municode
+LBT_CFLAGS += -municode
 endif
 
 # On windows, we must generate import libraries
@@ -62,7 +61,7 @@ endif
 # from returning doubles to instead return float's.  We enable automatic F2C detection on those platforms.
 F2C_AUTODETECTION := 0
 ifeq ($(ARCH),x86_64)
-  override CFLAGS += -DF2C_AUTODETECTION
+  LBT_CFLAGS += -DF2C_AUTODETECTION
   F2C_AUTODETECTION := 1
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,15 +24,15 @@ $(builddir) $(builddir)/trampolines:
 	@mkdir -p $@
 
 $(builddir)/%.o: %.c | $(builddir) $(builddir)/trampolines
-	@$(call PRINT_CC,$(CC) -o $@ $(CFLAGS) -c $^)
+	@$(call PRINT_CC,$(CC) -o $@ $(LBT_CFLAGS) -c $^)
 $(builddir)/trampolines/%.o: trampolines/%.S exported_funcs.inc | $(builddir)/trampolines
-	@$(call PRINT_CC,$(CC) -o $@ $(CFLAGS) -c $<)
+	@$(call PRINT_CC,$(CC) -o $@ $(LBT_CFLAGS) -c $<)
 
 dump-trampolines: trampolines/trampolines_$(ARCH).S
 	$(CC) $< -S | sed -E 's/ ((%%)|;) /\n/g' | sed -E 's/.global/\n.global/g'
 
 $(builddir)/libblastrampoline.$(SHLIB_EXT): $(MAIN_OBJS)
-	@$(call PRINT_CC,$(CC) -o $@ $(call IMPLIB_FLAGS,$@) $(CFLAGS) $^ $(LDFLAGS))
+	@$(call PRINT_CC,$(CC) -o $@ $(call IMPLIB_FLAGS,$@) $(LBT_CFLAGS) $^ $(LBT_LDFLAGS))
 
 # Install both libraries and our headers
 install: $(builddir)/libblastrampoline.$(SHLIB_EXT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ dump-trampolines: trampolines/trampolines_$(ARCH).S
 	$(CC) $< -S | sed -E 's/ ((%%)|;) /\n/g' | sed -E 's/.global/\n.global/g'
 
 $(builddir)/libblastrampoline.$(SHLIB_EXT): $(MAIN_OBJS)
-	@$(call PRINT_CC,$(CC) -o $@ $(call IMPLIB_FLAGS,$@) $(LBT_CFLAGS) $^ $(LBT_LDFLAGS))
+	@$(call PRINT_CC,$(CC) -o $@ $(call IMPLIB_FLAGS,$@) $(LBT_CFLAGS) $^ -shared $(LBT_LDFLAGS))
 
 # Install both libraries and our headers
 install: $(builddir)/libblastrampoline.$(SHLIB_EXT)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -64,8 +64,8 @@ function get_blastrampoline_dir()
     cflags_add = needs_m32() ? "-m32" : ""
     dir = mktempdir()
     srcdir = joinpath(dirname(@__DIR__), "src")
-    run(`$(make) -sC $(pathesc(srcdir)) CFLAGS_add=$(cflags_add) ARCH=$(Sys.ARCH) clean`)
-    run(`$(make) -sC $(pathesc(srcdir)) CFLAGS_add=$(cflags_add) ARCH=$(Sys.ARCH) install builddir=$(pathesc(dir))/build prefix=$(pathesc(dir))/output`)
+    run(`$(make) -sC $(pathesc(srcdir)) CFLAGS=$(cflags_add) ARCH=$(Sys.ARCH) clean`)
+    run(`$(make) -sC $(pathesc(srcdir)) CFLAGS=$(cflags_add) ARCH=$(Sys.ARCH) install builddir=$(pathesc(dir))/build prefix=$(pathesc(dir))/output`)
     global blastrampoline_build_dir = joinpath(dir, "output")
     return blastrampoline_build_dir
 end


### PR DESCRIPTION
Fix #44.  @nalimilan could you please test this out?  I think this is now doing
what you want:

```console
% LANG=C make -C src CFLAGS="" LDFLAGS="" VERBOSE=1
make: Entering directory '/home/mose/repo/libblastrampoline/src'
cc -o build/libblastrampoline.o -fPIC -DF2C_AUTODETECTION -c libblastrampoline.c
cc -o build/dl_utils.o -fPIC -DF2C_AUTODETECTION -c dl_utils.c
cc -o build/config.o -fPIC -DF2C_AUTODETECTION -c config.c
cc -o build/autodetection.o -fPIC -DF2C_AUTODETECTION -c autodetection.c
cc -o build/threading.o -fPIC -DF2C_AUTODETECTION -c threading.c
cc -o build/deepbindless_surrogates.o -fPIC -DF2C_AUTODETECTION -c deepbindless_surrogates.c
cc -o build/trampolines/trampolines_x86_64.o -fPIC -DF2C_AUTODETECTION -c trampolines/trampolines_x86_64.S
cc -o build/f2c_adapters.o -fPIC -DF2C_AUTODETECTION -c f2c_adapters.c
cc -o build/libblastrampoline.so -fPIC -DF2C_AUTODETECTION build/libblastrampoline.o build/dl_utils.o build/config.o build/autodetection.o build/threading.o build/deepbindless_surrogates.o build/trampolines/trampolines_x86_64.o build/f2c_adapters.o -shared -ldl
make: Leaving directory '/home/mose/repo/libblastrampoline/src'
```