### PR TITLE
Add `-fvisibility=protected` on Linux

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -35,13 +35,15 @@ endif
 CFLAGS := -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE $(CFLAGS_add)
 LDFLAGS := -shared
 
-# On linux, we need to link `libdl` to get `dlopen`
 ifeq ($(OS),Linux)
+# On linux, we need to link `libdl` to get `dlopen`
 LDFLAGS += -ldl
+# We also want `-fvisibility=protected` on Linux, to match other platforms
+CFLAGS += -fvisibility=protected
 endif
 
-# On windows, we need to enable unicode mode
 ifeq ($(OS),WINNT)
+# On windows, we need to enable unicode mode
 CFLAGS += -municode
 endif
 


### PR DESCRIPTION
This ensures that functions that are not explicitly exported don't jump
through a PLT trampoline.  This furthermore prevents things like
`load_library()` getting overrided by the `load_library()` symbol in
`bin/julia`.