### PR TITLE
Add `LBT_USE_RTLD_DEEPBIND` capability

### DIFF
--- a/src/Make.inc
+++ b/src/Make.inc
@@ -40,6 +40,10 @@ ifeq ($(OS),Linux)
 LDFLAGS += -ldl
 # We also want `-fvisibility=protected` on Linux, to match other platforms
 CFLAGS += -fvisibility=protected
+# There are bugs with `-fvisibility=protected` and certain versions of `ld`,
+# see https://sourceware.org/bugzilla/show_bug.cgi?id=26815 for more
+# We work around this by using `gold` on Linux
+LDFLAGS += -fuse-ld=gold
 endif
 
 ifeq ($(OS),WINNT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ include $(LBT_ROOT)/src/Make.inc
 all: $(builddir)/libblastrampoline.$(SHLIB_EXT)
 
 # Objects we'll build
-MAIN_OBJS := libblastrampoline.o dl_utils.o config.o autodetection.o threading.o deepbindless_surrogates.o trampolines/trampolines_$(ARCH).o
+MAIN_OBJS := libblastrampoline.o dl_utils.o config.o autodetection.o threading.o deepbindless.o trampolines/trampolines_$(ARCH).o
 
 # Include win_utils.c on windws
 ifeq ($(OS),WINNT)

--- a/src/autodetection.c
+++ b/src/autodetection.c
@@ -46,13 +46,15 @@ int32_t autodetect_blas_interface(void * isamax_addr) {
     int64_t incx = 1;
 
     // Override `lsame_` to point to our `fake_lsame` if we're unable to `RTLD_DEEPBIND`
-#ifdef LBT_DEEPBINDLESS
-    push_fake_lsame();
-#endif
+    if (use_deepbind == 0) {
+        push_fake_lsame();
+    }
+
     int64_t max_idx = isamax(&n, X, &incx);
-#ifdef LBT_DEEPBINDLESS
-    pop_fake_lsame();
-#endif
+
+    if (use_deepbind == 0) {
+        pop_fake_lsame();
+    }
 
     // Although we declare that `isamax` returns an `int64_t`, it may not actually do so,
     // since if it's an LP64 binary it's probably returning an `int32_t`.  Depending on the

--- a/src/deepbindless.c
+++ b/src/deepbindless.c
@@ -1,6 +1,20 @@
 #include "libblastrampoline_internal.h"
 
-#if defined(LBT_DEEPBINDLESS)
+/*
+ * Users can force an RTLD_DEEPBIND-capable system to avoid using RTLD_DEEPBIND
+ * by setting `LBT_USE_RTLD_DEEPBIND=0` in their environment.  This function
+ * returns `0x01` if it will use `RTLD_DEEPBIND` when loading a library, and
+ * `0x00` otherwise.
+ */
+#if defined(LBT_DEEPBINDLESS) || !defined(RTLD_DEEPBIND)
+uint8_t use_deepbind = 0x00;
+#else
+uint8_t use_deepbind = 0x01;
+#endif
+LBT_DLLEXPORT const uint8_t lbt_get_use_deepbind() {
+    return use_deepbind;
+}
+
 
 int lsame_idx = -1;
 const void *old_lsame32 = NULL, *old_lsame64 = NULL;
@@ -76,5 +90,3 @@ int fake_lsame(char * ca, char * cb) {
     }
     return inta == intb;
 }
-
-#endif // LBT_DEEPBINDLESS

--- a/src/libblastrampoline.h
+++ b/src/libblastrampoline.h
@@ -162,6 +162,13 @@ LBT_DLLEXPORT void lbt_default_func_print_error();
 LBT_DLLEXPORT const void * lbt_get_default_func();
 
 /*
+ * Users can force an RTLD_DEEPBIND-capable system to avoid using RTLD_DEEPBIND by setting
+ * `LBT_USE_RTLD_DEEPBIND=0` in their environment.  This function returns `0x01` if it will
+ *  use `RTLD_DEEPBIND` when loading a library, and `0x00` otherwise.
+ */
+ LBT_DLLEXPORT const uint8_t lbt_get_use_deepbind();
+
+/*
  * Sets the default function that gets called if no mapping has been set for an exported symbol.
  * `NULL` is a valid address, if a segfault upon calling an uninitialized function is desirable.
  * Note that this will not be retroactively applied to already-set pointers, so you should call

--- a/src/libblastrampoline_internal.h
+++ b/src/libblastrampoline_internal.h
@@ -82,9 +82,8 @@ int32_t autodetect_interface(void * handle, const char * suffix);
 int autodetect_f2c(void * handle, const char * suffix);
 #endif
 
-#ifdef LBT_DEEPBINDLESS
 // Functions in deepbindless_surrogates.c
 void push_fake_lsame();
 void pop_fake_lsame();
 int fake_lsame(char * ca, char * cb);
-#endif
+extern uint8_t use_deepbind;


### PR DESCRIPTION
Certain tools such as sanitizers don't like us loading libraries with
`RTLD_DEEPBIND`, so since we already have the workarounds in place for
systems that don't have `RTLD_DEEPBIND` at all, let's change these from
using compile-time constants to instead use a runtime switch that can be
overridden through setting the environment variable
`LBT_USE_RTLD_DEEPBIND=0` before running our program.