### PR TITLE
Use Alpine 3.13 and remove `-fvisibility=protected` `-fuse-ld=gold` flags

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -8,7 +8,9 @@ local Pipeline(os, arch, version, alpine=false) = {
     steps: [
         {
             name: "Run tests",
-            image: "julia:"+version+(if alpine then "-alpine" else ""),
+            # Use Alpine 3.13 because 3.14 has some troubles with Docker due to
+            # https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
+            image: "julia:"+version+(if alpine then "-alpine3.13" else ""),
             commands: [
                 (if alpine then "" else "apt-get update -y"),
                 (if alpine then "apk add build-base linux-headers" else "apt-get install -y gcc build-essential"),

--- a/.drone.yml
+++ b/.drone.yml
@@ -52,7 +52,7 @@ platform:
 
 steps:
 - name: Run tests
-  image: julia:1.6-alpine
+  image: julia:1.6-alpine3.13
   commands:
   - ""
   - apk add build-base linux-headers

--- a/src/Make.inc
+++ b/src/Make.inc
@@ -38,12 +38,6 @@ LDFLAGS := -shared
 ifeq ($(OS),Linux)
 # On linux, we need to link `libdl` to get `dlopen`
 LDFLAGS += -ldl
-# We also want `-fvisibility=protected` on Linux, to match other platforms
-CFLAGS += -fvisibility=protected
-# There are bugs with `-fvisibility=protected` and certain versions of `ld`,
-# see https://sourceware.org/bugzilla/show_bug.cgi?id=26815 for more
-# We work around this by using `gold` on Linux
-LDFLAGS += -fuse-ld=gold
 endif
 
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
`-fvisibility=protected` doesn't really help us much and causes the following
error on Alpine Linux:
```
cc -o /tmp/jl_ACPfla/build/libblastrampoline.so -g -O2 -std=c99 -fPIC -DLIBRARY_EXPORTS -D_GNU_SOURCE -fvisibility=protected -DF2C_AUTODETECTION /tmp/jl_ACPfla/build/libblastrampoline.o /tmp/jl_ACPfla/build/dl_utils.o /tmp/jl_ACPfla/build/config.o /tmp/jl_ACPfla/build/autodetection.o /tmp/jl_ACPfla/build/threading.o /tmp/jl_ACPfla/build/deepbindless_surrogates.o /tmp/jl_ACPfla/build/trampolines/trampolines_x86_64.o /tmp/jl_ACPfla/build/f2c_adapters.o -shared -ldl
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/jl_ACPfla/build/deepbindless_surrogates.o: relocation R_X86_64_PC32 against protected symbol `fake_lsame' can not be used when making a shared object
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make: *** [Makefile:35: /tmp/jl_ACPfla/build/libblastrampoline.so] Error 1
ERROR: LoadError: failed process: Process(`make -sC /libblastrampoline/src CFLAGS_add= ARCH=x86_64 install builddir=/tmp/jl_ACPfla/build prefix=/tmp/jl_ACPfla/output`, ProcessExited(2)) [2]
```
and `-fuse-ld=gold` was only needed to make `-fvisibility=protected` work (and
it isn't even available on Alpine Linux in our current CI set up).
